### PR TITLE
Fix example code

### DIFF
--- a/example_data/example.py
+++ b/example_data/example.py
@@ -45,7 +45,7 @@ chn_data = GeneratorCfg(
                 **font_cfg
             ),
         ),
-        corpus_effects=Effects([Line(0.5), OneOf([DropoutRand(), DropoutVertical()])]),
+        corpus_effects=Effects([Line(0.5)]),
     ),
 )
 


### PR DESCRIPTION
`OneOf`, despite being in the `effect` module is NOT an `Effect` and cannot be used in an `Effects` array.

![image](https://user-images.githubusercontent.com/38930062/128104595-cfeeb1cf-6777-4c29-9ce6-697700cef6b1.png)

See the above screenshot for reference.