### PR TITLE
fix: Add space checks for dropout and line effects

### DIFF
--- a/text_renderer/effect/dropout_horizontal.py
+++ b/text_renderer/effect/dropout_horizontal.py
@@ -24,6 +24,11 @@ class DropoutHorizontal(Effect):
         self.thickness = thickness
 
     def apply(self, img: PILImage, text_bbox: BBox) -> Tuple[PILImage, BBox]:
+        # Check if there's enough space for the dropout effect
+        if img.height <= self.thickness + 1:
+            # Not enough space for dropout, return original image
+            return img, text_bbox
+            
         pim = img.load()
 
         for _ in range(self.num_line):

--- a/text_renderer/effect/dropout_vertical.py
+++ b/text_renderer/effect/dropout_vertical.py
@@ -24,6 +24,11 @@ class DropoutVertical(Effect):
         self.thickness = thickness
 
     def apply(self, img: PILImage, text_bbox: BBox) -> Tuple[PILImage, BBox]:
+        # Check if there's enough space for the dropout effect
+        if img.width <= self.thickness + 1:
+            # Not enough space for dropout, return original image
+            return img, text_bbox
+            
         pim = img.load()
 
         for _ in range(self.num_line):

--- a/text_renderer/effect/line.py
+++ b/text_renderer/effect/line.py
@@ -71,6 +71,11 @@ class Line(Effect):
     def apply_horizontal_middle(
         self, img: PILImage, text_bbox: BBox
     ) -> Tuple[PILImage, BBox]:
+        # Check if there's enough space for the horizontal line
+        if img.height <= 2:
+            # Not enough space for horizontal line, return original image
+            return img, text_bbox
+            
         row = np.random.randint(1, img.height - 1)
         thickness = np.random.randint(*self.thickness)
 
@@ -87,6 +92,11 @@ class Line(Effect):
     def apply_vertical_middle(
         self, img: PILImage, text_bbox: BBox
     ) -> Tuple[PILImage, BBox]:
+        # Check if there's enough space for the vertical line
+        if img.width <= 2:
+            # Not enough space for vertical line, return original image
+            return img, text_bbox
+            
         col = np.random.randint(1, img.width - 1)
         thickness = np.random.randint(*self.thickness)
 


### PR DESCRIPTION
- Implemented checks in the apply methods of DropoutHorizontal, DropoutVertical, and Line classes to ensure there is sufficient space for the effects to be applied. If the image dimensions are too small, the original image is returned without modification.