### PR TITLE
fix: Ensure default background is created when no images are found

### DIFF
--- a/text_renderer/bg_manager.py
+++ b/text_renderer/bg_manager.py
@@ -30,7 +30,12 @@ class BgManager:
                     if pre_load:
                         self.bg_imgs.append(self._get_bg(str(p)))
 
-        assert len(self.bg_imgs) != 0, "background image is empty"
+        if len(self.bg_imgs) == 0:
+            logger.warning("No background images found. Creating a default white background.")
+            # Create a default white background
+            default_bg = Image.new('RGB', (800, 600), (255, 255, 255))
+            self.bg_imgs = [default_bg]
+            self.bg_paths = ['default_white']
 
     def _is_transparent_image(self, p: Path):
         pil_img: PILImage = Image.open(p)


### PR DESCRIPTION
- Added a warning log when no background images are loaded.
- Implemented creation of a default white background if the background images list is empty.