### PR TITLE
chore: replace black/isort/flake8 with ruff and add lint CI

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -7,6 +7,26 @@ on:
     branches: [ master ]
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v5
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v7
+      with:
+        python-version: "3.10"
+
+    - name: Install dependencies
+      run: uv sync --locked
+
+    - name: Ruff lint
+      run: uv run ruff check .
+
+    - name: Ruff format check
+      run: uv run ruff format --check .
+
   test:
     runs-on: ubuntu-latest
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,24 +9,12 @@ repos:
       - id: check-merge-conflict
       - id: debug-statements
 
-  - repo: https://github.com/psf/black
-    rev: 23.12.1
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.4.10
     hooks:
-      - id: black
-        language_version: python3
-        args: [--line-length=88]
-
-  - repo: https://github.com/pycqa/isort
-    rev: 5.13.2
-    hooks:
-      - id: isort
-        args: [--profile=black, --line-length=88]
-
-  - repo: https://github.com/pycqa/flake8
-    rev: 7.0.0
-    hooks:
-      - id: flake8
-        args: [--max-line-length=88, --extend-ignore=E203,W503]
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format
 
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.8.0

--- a/README.md
+++ b/README.md
@@ -37,14 +37,10 @@ Generate text line images for training deep learning OCR model (e.g. [CRNN](http
 ```bash
 git clone https://github.com/oh-my-ocr/text_renderer
 cd text_renderer
-uv sync
-```
-
-Or with pip:
-
-```bash
-pip install '.[tools]'   # includes font viewer and utility scripts
-pip install '.[docs]'    # includes Sphinx for building documentation
+uv sync                              # core dependencies
+uv sync --extra tools                # + font viewer and utility scripts
+uv sync --extra docs                 # + Sphinx for building documentation
+uv sync --all-extras                 # everything
 ```
 
 ## Run Example

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,3 @@
-import sphinx_rtd_theme
 import os
 import sys
 
@@ -14,7 +13,7 @@ import sys
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-sys.path.insert(0, os.path.abspath('..'))
+sys.path.insert(0, os.path.abspath(".."))
 
 
 # -- Project information -----------------------------------------------------

--- a/example_data/effect_layout_example.py
+++ b/example_data/effect_layout_example.py
@@ -3,19 +3,13 @@
 # 2. Update README.md
 import inspect
 import os
-from dataclasses import dataclass
 from pathlib import Path
-
-import numpy as np
 
 from text_renderer.config import (
     FixedPerspectiveTransformCfg,
     FixedTextColorCfg,
     GeneratorCfg,
-    NormPerspectiveTransformCfg,
     RenderCfg,
-    SimpleTextColorCfg,
-    TextColorCfg,
 )
 from text_renderer.corpus import *
 from text_renderer.effect import *

--- a/example_data/example.py
+++ b/example_data/example.py
@@ -40,7 +40,7 @@ def get_char_corpus():
             chars_file=CHAR_DIR / "chn.txt",
             length=(5, 10),
             char_spacing=(-0.3, 1.3),
-            **font_cfg
+            **font_cfg,
         ),
     )
 
@@ -84,7 +84,7 @@ def enum_data():
                 text_paths=[TEXT_DIR / "enum_text.txt"],
                 filter_by_chars=True,
                 chars_file=CHAR_DIR / "chn.txt",
-                **font_cfg
+                **font_cfg,
             ),
         ),
     )
@@ -107,7 +107,7 @@ def eng_word_data():
                 text_paths=[TEXT_DIR / "eng_text.txt"],
                 filter_by_chars=True,
                 chars_file=CHAR_DIR / "eng.txt",
-                **font_cfg
+                **font_cfg,
             ),
         ),
     )
@@ -124,7 +124,7 @@ def same_line_data():
                     text_paths=[TEXT_DIR / "enum_text.txt"],
                     filter_by_chars=True,
                     chars_file=CHAR_DIR / "chn.txt",
-                    **font_cfg
+                    **font_cfg,
                 ),
             ),
             CharCorpus(

--- a/main.py
+++ b/main.py
@@ -82,12 +82,12 @@ class DBWriterProcess(Process):
                     count += 1
                     if count % log_period == 0:
                         logger.info(
-                            f"{(count/num_image)*100:.2f}%({count}/{num_image}) {log_period/(time.time() - start + 1e-8):.1f} img/s"
+                            f"{(count / num_image) * 100:.2f}%({count}/{num_image}) {log_period / (time.time() - start + 1e-8):.1f} img/s"
                         )
                         start = time.time()
                 db.write_count(count + exist_count)
                 logger.info(f"{(count / num_image) * 100:.2f}%({count}/{num_image})")
-                logger.info(f"Finish generate: {count}. Total: {exist_count+count}")
+                logger.info(f"Finish generate: {count}. Total: {exist_count + count}")
         except Exception as e:
             logger.exception("DBWriterProcess error")
             raise e

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,14 +40,18 @@ tools = [
 dev = [
     "pre-commit>=3.0.0",
     "pytest>=6.0.0",
+    "ruff>=0.4.0",
 ]
 
-[tool.black]
+[tool.ruff]
 line-length = 88
+target-version = "py310"
 
-[tool.isort]
-profile = "black"
-line_length = 88
+[tool.ruff.lint]
+extend-select = ["I"]
+
+[tool.ruff.lint.per-file-ignores]
+"example_data/*" = ["F403", "F405"]
 
 [tool.pytest.ini_options]
 testpaths = ["text_renderer/tests"]

--- a/text_renderer/__init__.py
+++ b/text_renderer/__init__.py
@@ -13,7 +13,7 @@ Main components:
 Example:
     from text_renderer import Render
     from text_renderer.config import RenderCfg
-    
+
     cfg = RenderCfg(...)
     renderer = Render(cfg)
     image, text = renderer()

--- a/text_renderer/bg_manager.py
+++ b/text_renderer/bg_manager.py
@@ -31,11 +31,13 @@ class BgManager:
                         self.bg_imgs.append(self._get_bg(str(p)))
 
         if len(self.bg_imgs) == 0:
-            logger.warning("No background images found. Creating a default white background.")
+            logger.warning(
+                "No background images found. Creating a default white background."
+            )
             # Create a default white background
-            default_bg = Image.new('RGB', (800, 600), (255, 255, 255))
+            default_bg = Image.new("RGB", (800, 600), (255, 255, 255))
             self.bg_imgs = [default_bg]
-            self.bg_paths = ['default_white']
+            self.bg_paths = ["default_white"]
 
     def _is_transparent_image(self, p: Path):
         pil_img: PILImage = Image.open(p)

--- a/text_renderer/config/__init__.py
+++ b/text_renderer/config/__init__.py
@@ -244,9 +244,9 @@ def get_cfg(config_file: str) -> List[GeneratorCfg]:
     if cfgs is None:
         raise RuntimeError(f"Load configs failed: {config_file}")
 
-    assert all(
-        [isinstance(cfg, GeneratorCfg) for cfg in cfgs]
-    ), "Please make sure all items in configs is GeneratorCfg"
+    assert all([isinstance(cfg, GeneratorCfg) for cfg in cfgs]), (
+        "Please make sure all items in configs is GeneratorCfg"
+    )
 
     return cfgs
 

--- a/text_renderer/corpus/char_corpus.py
+++ b/text_renderer/corpus/char_corpus.py
@@ -27,6 +27,7 @@ class CharCorpusCfg(CorpusCfg):
         filter_font_min_support_chars (int): If intersection of font support chars with chars file is lower
                                              than filter_font_min_support_chars, filter this font file.
     """
+
     text_paths: List[Path] = field(default_factory=list)
     length: Tuple[int, int] = (5, 10)
     filter_by_chars: bool = False
@@ -50,7 +51,7 @@ class CharCorpus(Corpus):
         self.text = ""
 
         if len(self.cfg.text_paths) == 0:
-            raise PanicError(f"text_paths must not contain path")
+            raise PanicError("text_paths must not contain path")
 
         for p in self.cfg.text_paths:
             if not os.path.exists(p):

--- a/text_renderer/corpus/corpus.py
+++ b/text_renderer/corpus/corpus.py
@@ -1,11 +1,10 @@
-import os
 from abc import abstractmethod
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Tuple, Union
 
 from loguru import logger
-from tenacity import retry, stop_after_attempt
+from tenacity import retry
 
 from text_renderer.config import SimpleTextColorCfg, TextColorCfg
 from text_renderer.font_manager import FontManager
@@ -39,6 +38,7 @@ class CorpusCfg:
             generate the horizontal(default) or vertical text
             Set False to generate vertical text
     """
+
     font_dir: Path
     font_size: Tuple[int, int]
     font_list_file: Path = None
@@ -155,7 +155,7 @@ class Corpus:
                     filtered_chars.append(c)
                 total_count += 1
         logger.info(
-            f"Filter {(filtered_count/total_count)*100:.2f}%({filtered_count}) chars in input text。"
+            f"Filter {(filtered_count / total_count) * 100:.2f}%({filtered_count}) chars in input text。"
             f"Unique chars({len(set(filtered_chars))}): {set(filtered_chars)}"
         )
         return out

--- a/text_renderer/corpus/enum_corpus.py
+++ b/text_renderer/corpus/enum_corpus.py
@@ -2,9 +2,6 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import List
 
-import numpy as np
-from loguru import logger
-
 from text_renderer.utils.errors import PanicError
 from text_renderer.utils.utils import random_choice
 
@@ -50,10 +47,10 @@ class EnumCorpus(Corpus):
 
         self.cfg: EnumCorpusCfg
         if len(self.cfg.text_paths) == 0 and len(self.cfg.items) == 0:
-            raise PanicError(f"text_paths or items must not be empty")
+            raise PanicError("text_paths or items must not be empty")
 
         if len(self.cfg.text_paths) != 0 and len(self.cfg.items) != 0:
-            raise PanicError(f"only one of text_paths or items can be set")
+            raise PanicError("only one of text_paths or items can be set")
 
         self.texts: List[str] = []
 

--- a/text_renderer/corpus/word_corpus.py
+++ b/text_renderer/corpus/word_corpus.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import List, Tuple
+from typing import List
 
 import numpy as np
 from loguru import logger

--- a/text_renderer/effect/__init__.py
+++ b/text_renderer/effect/__init__.py
@@ -3,15 +3,8 @@ from .albumentations_effect import (
     AlbumentationsEffect,
     BrightnessContrast,
     ElasticTransform,
-)
-from .albumentations_effect import Emboss as AlbumentationsEmboss
-from .albumentations_effect import GaussianBlur, GridDistortion
-from .albumentations_effect import MotionBlur as AlbumentationsMotionBlur
-
-# Create aliases for backward compatibility
-Emboss = AlbumentationsEmboss
-MotionBlur = AlbumentationsMotionBlur
-from .albumentations_effect import (
+    GaussianBlur,
+    GridDistortion,
     Noise,
     OpticalDistortion,
     PoissonNoise,
@@ -20,7 +13,10 @@ from .albumentations_effect import (
     ShiftScaleRotate,
     UniformNoise,
 )
+from .albumentations_effect import Emboss as AlbumentationsEmboss
+from .albumentations_effect import MotionBlur as AlbumentationsMotionBlur
 from .base_effect import Effect, Effects, NoEffects
+from .curve import Curve
 from .dropout_horizontal import DropoutHorizontal
 from .dropout_rand import DropoutRand
 from .dropout_vertical import DropoutVertical
@@ -28,7 +24,10 @@ from .line import Line
 from .padding import Padding
 from .selector import OneOf
 from .text_border import TextBorder
-from .curve import Curve
+
+# Create aliases for backward compatibility
+Emboss = AlbumentationsEmboss
+MotionBlur = AlbumentationsMotionBlur
 
 __all__ = [
     "Effect",

--- a/text_renderer/effect/albumentations_effect.py
+++ b/text_renderer/effect/albumentations_effect.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple, Union
+from typing import Tuple
 
 import albumentations as A
 import numpy as np
@@ -25,16 +25,20 @@ class AlbumentationsEffect(Effect):
 
         # Convert PIL image to numpy array
         img_array = np.array(img)
-        
+
         # Check if image has alpha channel (RGBA)
         has_alpha = img_array.shape[-1] == 4
-        
+
         if has_alpha:
             # Convert RGBA to RGB for albumentations
             # Create a white background and composite the RGBA image onto it
-            rgb_array = np.zeros((img_array.shape[0], img_array.shape[1], 3), dtype=np.uint8)
+            rgb_array = np.zeros(
+                (img_array.shape[0], img_array.shape[1], 3), dtype=np.uint8
+            )
             alpha = img_array[:, :, 3:4] / 255.0
-            rgb_array = (img_array[:, :, :3] * alpha + (1 - alpha) * 255).astype(np.uint8)
+            rgb_array = (img_array[:, :, :3] * alpha + (1 - alpha) * 255).astype(
+                np.uint8
+            )
         else:
             rgb_array = img_array
 
@@ -45,10 +49,12 @@ class AlbumentationsEffect(Effect):
         # Convert back to PIL image
         if has_alpha:
             # Convert back to RGBA by adding the original alpha channel
-            rgba_array = np.zeros((transformed_img.shape[0], transformed_img.shape[1], 4), dtype=np.uint8)
+            rgba_array = np.zeros(
+                (transformed_img.shape[0], transformed_img.shape[1], 4), dtype=np.uint8
+            )
             rgba_array[:, :, :3] = transformed_img
             rgba_array[:, :, 3] = img_array[:, :, 3]  # Preserve original alpha
-            return Image.fromarray(rgba_array, mode='RGBA'), text_bbox
+            return Image.fromarray(rgba_array, mode="RGBA"), text_bbox
         else:
             return Image.fromarray(transformed_img), text_bbox
 
@@ -162,9 +168,7 @@ class SaltPepperNoise(AlbumentationsEffect):
         p: float
             Probability of applying this effect
         """
-        transform = A.SaltAndPepper(
-            p=p, salt_vs_pepper=(0.4, 0.6), amount=(0.02, 0.06)
-        )
+        transform = A.SaltAndPepper(p=p, salt_vs_pepper=(0.4, 0.6), amount=(0.02, 0.06))
         super().__init__(p, transform)
 
 
@@ -172,7 +176,7 @@ class PoissonNoise(AlbumentationsEffect):
     def __init__(self, p=1.0, intensity=(0.1, 0.5), color_shift=(0.01, 0.05)):
         """
         Poisson noise effect using Albumentations ISONoise
-        
+
         ISONoise simulates camera sensor noise which follows a Poisson distribution
         characteristic of photon counting noise in digital imaging.
 
@@ -185,11 +189,7 @@ class PoissonNoise(AlbumentationsEffect):
         color_shift: tuple
             Range for color shift values
         """
-        transform = A.ISONoise(
-            intensity=intensity,
-            color_shift=color_shift,
-            p=1.0
-        )
+        transform = A.ISONoise(intensity=intensity, color_shift=color_shift, p=1.0)
         super().__init__(p, transform)
 
 

--- a/text_renderer/effect/dropout_horizontal.py
+++ b/text_renderer/effect/dropout_horizontal.py
@@ -28,7 +28,7 @@ class DropoutHorizontal(Effect):
         if img.height <= self.thickness + 1:
             # Not enough space for dropout, return original image
             return img, text_bbox
-            
+
         pim = img.load()
 
         for _ in range(self.num_line):

--- a/text_renderer/effect/dropout_vertical.py
+++ b/text_renderer/effect/dropout_vertical.py
@@ -28,7 +28,7 @@ class DropoutVertical(Effect):
         if img.width <= self.thickness + 1:
             # Not enough space for dropout, return original image
             return img, text_bbox
-            
+
         pim = img.load()
 
         for _ in range(self.num_line):

--- a/text_renderer/effect/line.py
+++ b/text_renderer/effect/line.py
@@ -75,7 +75,7 @@ class Line(Effect):
         if img.height <= 2:
             # Not enough space for horizontal line, return original image
             return img, text_bbox
-            
+
         row = np.random.randint(1, img.height - 1)
         thickness = np.random.randint(*self.thickness)
 
@@ -96,7 +96,7 @@ class Line(Effect):
         if img.width <= 2:
             # Not enough space for vertical line, return original image
             return img, text_bbox
-            
+
         col = np.random.randint(1, img.width - 1)
         thickness = np.random.randint(*self.thickness)
 

--- a/text_renderer/effect/text_border.py
+++ b/text_renderer/effect/text_border.py
@@ -2,7 +2,7 @@ import typing
 from typing import Tuple
 
 import numpy as np
-from PIL import Image, ImageDraw, ImageFilter
+from PIL import Image, ImageFilter
 
 from text_renderer.utils.bbox import BBox
 from text_renderer.utils.types import PILImage

--- a/text_renderer/layout/extra_text_line.py
+++ b/text_renderer/layout/extra_text_line.py
@@ -31,9 +31,9 @@ class ExtraTextLineLayout(Layout):
         text_bboxes: List[BBox],
         img_bboxes: List[BBox],
     ) -> List[BBox]:
-        assert (
-            len(text_bboxes) == 2
-        ), "ExtraTextLineLayout only support input two text bboxes"
+        assert len(text_bboxes) == 2, (
+            "ExtraTextLineLayout only support input two text bboxes"
+        )
 
         main_text_mask_bbox, extra_text_mask_bbox = (
             img_bboxes[0],

--- a/text_renderer/layout/same_line.py
+++ b/text_renderer/layout/same_line.py
@@ -4,7 +4,6 @@ import numpy as np
 
 from text_renderer.utils.bbox import BBox
 
-from ..utils import FontText
 from .layout import Layout
 
 

--- a/text_renderer/tests/test_load_chars.py
+++ b/text_renderer/tests/test_load_chars.py
@@ -1,5 +1,4 @@
 import os
-import sys
 from pathlib import Path
 
 import pytest

--- a/text_renderer/utils/__init__.py
+++ b/text_renderer/utils/__init__.py
@@ -1,1 +1,1 @@
-from .font_text import FontText
+from .font_text import FontText as FontText

--- a/text_renderer/utils/font_text.py
+++ b/text_renderer/utils/font_text.py
@@ -46,10 +46,10 @@ class FontText:
         # Use getbbox() instead of deprecated getoffset()
         bbox = self.font.getbbox(self.text)
         if bbox[2] > bbox[0] and bbox[3] > bbox[1]:  # Valid bbox
-            left, top, right, bottom = bbox
+            left, top, _, _ = bbox
         else:
             # Fallback for empty or invalid bbox
-            left, top, right, bottom = 0, 0, 0, self.font.size
+            left, top = 0, 0
         return 0 - left, 0 - top
 
     @property

--- a/tools/check_fonts.py
+++ b/tools/check_fonts.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-from typing import List
 
 from rich import print
 from rich.table import Table

--- a/tools/lmdb2img.py
+++ b/tools/lmdb2img.py
@@ -14,7 +14,7 @@ def hello(name="World"):
 def lmdb2img(input: str, output: str, num: int = -1):
     labels = []
     if os.path.exists(output):
-        print(f"Output exists.")
+        print("Output exists.")
         return
     else:
         os.makedirs(output)

--- a/uv.lock
+++ b/uv.lock
@@ -1513,6 +1513,31 @@ wheels = [
 ]
 
 [[package]]
+name = "ruff"
+version = "0.15.13"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/21/a7d5c126d5b557715ef81098f3db2fe20f622a039ff2e626af28d674ab80/ruff-0.15.13.tar.gz", hash = "sha256:f9d89f17f7ba7fb2ed42921f0df75da797a9a5d71bc39049e2c687cf2baf44b7", size = 4678180, upload-time = "2026-05-14T13:44:37.869Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c6/61/11d458dc6ac22504fd8e237b29dfd40504c7fbbcc8930402cfe51a8e63ed/ruff-0.15.13-py3-none-linux_armv6l.whl", hash = "sha256:444b580fc72fd6887e650acd3e575e18cdc79dbcf42fb4030b491057921f61f8", size = 10738279, upload-time = "2026-05-14T13:44:18.7Z" },
+    { url = "https://files.pythonhosted.org/packages/86/ca/caa871ee7be718c45256fada4e16a218ee3e33f0c4a46b729a60a24912e6/ruff-0.15.13-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:6590d009e7cb7ebf36f83dbdd44a3fa48a0994ff6f1cdc1b08006abe58f98dc7", size = 11124798, upload-time = "2026-05-14T13:44:06.427Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/19/43f5f2e568dddde567fc41f8471f9432c09563e19d3e617a48cfa52f8f0a/ruff-0.15.13-py3-none-macosx_11_0_arm64.whl", hash = "sha256:1c26d2f66163deeb6e08d8b39fbbe983ce3c71cea06a6d7591cfd1421793c629", size = 10460761, upload-time = "2026-05-14T13:44:04.375Z" },
+    { url = "https://files.pythonhosted.org/packages/99/df/cf938cd6de3003178f03ad7c1ea2a6c099468c03a35037985070b37e76be/ruff-0.15.13-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9dbd6f94b434f896308e4d57fb7bfde0d02b99f7a64b3bdab0fdfa6a864203a5", size = 10804451, upload-time = "2026-05-14T13:44:25.221Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/7d/5d0973129b154ded2225729169d7068f26b467760b146493fde138415f23/ruff-0.15.13-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bf3259f3be4d181bda591da5db2571aed6853c6a048157756448020bc6c5cd22", size = 10534285, upload-time = "2026-05-14T13:44:08.888Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/e3/6b999bbc66cd51e5f073842bc2a3995e99c5e0e72e16b15e7261f7abf57a/ruff-0.15.13-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ae9c17e5eb4430c154e76abc25d79a318190f5a997f38fb6b114416c5319ffc9", size = 11312063, upload-time = "2026-05-14T13:44:11.274Z" },
+    { url = "https://files.pythonhosted.org/packages/af/5a/642639e9f5db04f1e97fbd6e091c6fd20725bdf072fb114d00eefb9e6eb8/ruff-0.15.13-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2e2e39bff6c341f4b577a21b801326fab0b11847f48fcaa83f00a113c9b3cb55", size = 12183079, upload-time = "2026-05-14T13:44:01.634Z" },
+    { url = "https://files.pythonhosted.org/packages/19/4c/7585735f6b53b0f12de13618b2f7d250a844f018822efc899df2e7b8295f/ruff-0.15.13-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e8d9a8e08013542e94d3220bc5b62cc3e5ef87c5f74bff367d3fac14fab013e6", size = 11440833, upload-time = "2026-05-14T13:43:59.043Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/31/bf1a0803d077e679cfeee5f2f67290a0fa79c7385b5d9a8c17b9db2c48f0/ruff-0.15.13-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cc411dfebe5eebe55ce041c6ae080eb7668955e866daa2fbb16692a784f1c4ca", size = 11434486, upload-time = "2026-05-14T13:44:27.761Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/4e/62c9b999875d4f14db80f277c030578f5e249c9852d65b7ac7ad0b43c041/ruff-0.15.13-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:768494eb08b9cee54e2fd27969966f74db5a57f6eaa7a90fcb3306af34dfc4bd", size = 11385189, upload-time = "2026-05-14T13:44:13.704Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/89/7e959047a104df3eb12863447c110140191fc5b6c4f379ea2e803fcdb0e4/ruff-0.15.13-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:fb75f9a3a7e42ffe117d734494e6c5e5cb3565d66e12612cb63d0e572a41a5b6", size = 10781380, upload-time = "2026-05-14T13:43:56.734Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/52/5fd18f3b88cab63e88aa11516b3b4e1e5f720e5c330f8dbe5c26210f41f8/ruff-0.15.13-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:8cb74dd33bb2f6613faf7fc03b660053b5ac4f80e706d5788c6335e2a8048d51", size = 10540605, upload-time = "2026-05-14T13:44:20.748Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/e0/9e35f338990d3e41a82875ff7053ffe97541dae81c9d02143177f381d572/ruff-0.15.13-py3-none-musllinux_1_2_i686.whl", hash = "sha256:7ef823f817fcd191dc934e984be9cf4094f808effa16f2542ad8e821ba02bbf2", size = 11036554, upload-time = "2026-05-14T13:44:16.256Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/13/070fb048c24080fba188f66371e2a92785be257ad02242066dc7255ac6e9/ruff-0.15.13-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:f345a13937bd7f09f6f5d19fa0721b0c103e00e7f62bc67089a8e5e037719e0b", size = 11528133, upload-time = "2026-05-14T13:44:22.808Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/8c/b1e1666aef7fc6555094d73ae6cd981701781ae85b97ceefc0eebd0b4668/ruff-0.15.13-py3-none-win32.whl", hash = "sha256:4044f94208b3b05ba0fc4a4abd0558cf4d6459bd18325eead7fd8cc66f909b41", size = 10721455, upload-time = "2026-05-14T13:44:35.697Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/a6/870a3e8a50590bb92be184ad928c2922f088b00d9dc5c5ec7b924ee08c22/ruff-0.15.13-py3-none-win_amd64.whl", hash = "sha256:7064884d442b7d477b4e7473d12da7f08851d2b1982763c5d3f388a19468a1a4", size = 11900409, upload-time = "2026-05-14T13:44:30.389Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/36/9c015cd052fca743dae8cb2aeb16b551444787467db42ceab0fc968865af/ruff-0.15.13-py3-none-win_arm64.whl", hash = "sha256:2471da9bd1068c8c064b5fd9c0c4b6dddffd6369cb1cd68b29993b1709ff1b21", size = 11179336, upload-time = "2026-05-14T13:44:33.026Z" },
+]
+
+[[package]]
 name = "scipy"
 version = "1.15.3"
 source = { registry = "https://pypi.org/simple" }
@@ -2020,6 +2045,7 @@ tools = [
 dev = [
     { name = "pre-commit" },
     { name = "pytest" },
+    { name = "ruff" },
 ]
 
 [package.metadata]
@@ -2049,6 +2075,7 @@ provides-extras = ["docs", "tools"]
 dev = [
     { name = "pre-commit", specifier = ">=3.0.0" },
     { name = "pytest", specifier = ">=6.0.0" },
+    { name = "ruff", specifier = ">=0.4.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Swap black, isort, and flake8 for ruff in `pyproject.toml` and `.pre-commit-config.yaml` (ruff covers all three; one tool, faster)
- Add a `lint` job to `.github/workflows/pytest.yml` that runs `ruff check` and `ruff format --check` so future drift is caught
- Fix README install instructions to use consistent `uv sync --extra ...` syntax instead of a mixed uv/pip flow
- Apply `ruff format` across the codebase and fix the small amount of pre-existing lint debt (unused imports, import ordering in `effect/__init__.py`, unused tuple unpacking in `font_text.py`)
- Add `per-file-ignores` for `example_data/*` to allow `import *` (intentional in example configs)

## Test plan
- [x] `uv run ruff check .` → all checks pass
- [x] `uv run ruff format --check .` → 47 files already formatted
- [x] `uv run pytest` → 4 passed
- [x] CI lint + test jobs both green on this PR