### PR TITLE
fix: preserve bg and mask panel width after resize

### DIFF
--- a/text_renderer/render.py
+++ b/text_renderer/render.py
@@ -107,7 +107,7 @@ class Render:
 
                 np_img = np.array(merge_target)
                 np_img = cv2.cvtColor(np_img, cv2.COLOR_RGBA2BGR)
-                np_img = self.norm(np_img)
+                np_img = self.norm(np_img, width_multiple=3)
             else:
                 img = img.convert("RGB")
                 np_img = np.array(img)
@@ -339,7 +339,7 @@ class Render:
         """
         return isinstance(self.corpus, list) and len(self.corpus) > 1
 
-    def norm(self, image: np.ndarray) -> np.ndarray:
+    def norm(self, image: np.ndarray, width_multiple: int = 1) -> np.ndarray:
         """
         Normalize the image according to configuration settings.
 
@@ -349,6 +349,7 @@ class Render:
 
         Args:
             image (np.ndarray): Input image as numpy array
+            width_multiple (int): Keep resized image width divisible by this value.
 
         Returns:
             np.ndarray: Normalized image
@@ -359,6 +360,8 @@ class Render:
         if self.cfg.height != -1 and self.cfg.height != image.shape[0]:
             height, width = image.shape[:2]
             width = int(width // (height / self.cfg.height))
+            if width_multiple > 1:
+                width = max(width_multiple, width - width % width_multiple)
             image = cv2.resize(
                 image, (width, self.cfg.height), interpolation=cv2.INTER_CUBIC
             )

--- a/text_renderer/tests/test_render_smoke.py
+++ b/text_renderer/tests/test_render_smoke.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 import numpy as np
 import pytest
+from PIL import Image
 
 from text_renderer.config import RenderCfg
 from text_renderer.corpus import EnumCorpus, EnumCorpusCfg
@@ -58,15 +59,23 @@ def test_render_color_mode_produces_three_channels():
     assert img.shape[2] == 3
 
 
-def test_render_return_bg_and_mask_produces_triple_width():
-    # Disable height normalization (height=-1) so the 3x-paste in
-    # Render.__call__ survives without integer-division rounding.
-    render = _make_render(gray=False, return_bg_and_mask=True, height=-1)
-    img, _ = render()
+def test_render_return_bg_and_mask_keeps_triple_width_after_height_normalization():
+    render = _make_render(gray=False, return_bg_and_mask=True, height=32)
+    size = (100, 37)
+    text_img = Image.new("RGB", size, (10, 20, 30))
+    bg_img = Image.new("RGB", size, (40, 50, 60))
+    text_mask = Image.new("RGBA", size, (255, 255, 255, 255))
 
-    # The merged output pastes [text | bg | mask] horizontally.
+    def fake_gen_single_corpus():
+        return text_img, "abc", bg_img, text_mask
+
+    render.gen_single_corpus = fake_gen_single_corpus
+
+    img, text = render()
+
+    assert text == "abc"
+    assert img.shape[0] == 32
     assert img.shape[1] % 3 == 0
-    assert img.shape[0] > 0
 
 
 def test_render_rejects_list_corpus_with_scalar_effects():


### PR DESCRIPTION
## Summary

Fix #91. When `RenderCfg(return_bg_and_mask=True)` was combined with height normalization, `Render.norm`'s integer-division resize broke the `width % 3 == 0` invariant that the `[text | bg | mask]` paste established, so downstream code that split the output into 3 equal panels misaligned by 1-2 px.

## Approach

Push the alignment constraint into `Render.norm` itself (that's where the resize happens) via a new `width_multiple: int = 1` parameter:

```python
def norm(self, image, width_multiple: int = 1):
    ...
    if width_multiple > 1:
        width = max(width_multiple, width - width % width_multiple)
```

The `return_bg_and_mask` branch in `__call__` passes `width_multiple=3`. The `max(width_multiple, ...)` guard prevents a 0-width image when the original width is smaller than `width_multiple`.

`width_multiple=1` default means all other call sites are unaffected (`width - width % 1 == width`, `max(1, width) == width`).

## Test

New regression test `test_render_return_bg_and_mask_keeps_triple_width_after_height_normalization` monkey-patches `gen_single_corpus` with a deterministic `(100, 37)` panel so the assertion isn't flaky. Without this fix the test fails (resize → 259 wide, `259 % 3 == 1`); with the fix it passes (258 wide, divisible by 3). The earlier `height=-1` smoke test is removed since this new one covers the real-world path.

## Test plan
- [x] `uv run pytest -v` → 10 passed
- [x] `uv run coverage run -m pytest && uv run coverage report --fail-under=45` → exit 0, 51% total
- [x] `uv run ruff check .` + `uv run ruff format --check .` → clean
- [x] CI lint + test green on this PR